### PR TITLE
Allow Item Links to open in new tab

### DIFF
--- a/src/app/@shared/@components/item-count/item-display.component.html
+++ b/src/app/@shared/@components/item-count/item-display.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="item; let itemDisplay">
     <h4 matLine>
         <ng-container *ngIf="itemDisplay.baseCount || itemDisplay.enchantedCount || itemDisplay.legendaryCount">
-            <a href="https://www.thjdi.cc/item/{{ itemDisplay.baseId + ItemQuality.Legendary }}" class="name-link">{{ itemDisplay.name }}</a>
+            <a href="https://www.thjdi.cc/item/{{ itemDisplay.baseId + ItemQuality.Legendary }}" class="name-link" target="_blank">{{ itemDisplay.name }}</a>
             <a href="https://www.thjdi.cc/item/{{ itemDisplay.baseId }}" *ngIf="itemDisplay.baseCount" class="green-text count-badge">{{
                 itemDisplay.baseCount
             }}</a


### PR DESCRIPTION
I added this because when viewing items it is nicer to have it open in an external tab rather than take over the current tab.