### PR TITLE
Fix scrollbar calc and remove filters from augs

### DIFF
--- a/src/app/@shared/@components/bank/bank.component.html
+++ b/src/app/@shared/@components/bank/bank.component.html
@@ -6,75 +6,79 @@
 </ng-container>
 
 <ng-template #mainContent>
-    <div class="last-updated-toast">
-        Last Updated: {{ lastModifiedDisplay$ | async }}
-    </div>
-
-    <mat-card appearance="outlined">
-        <mat-card-content>
-            <mat-form-field appearance="fill" class="spaced-input" subscriptSizing="dynamic">
-                <mat-label>Search</mat-label>
-                <input matInput placeholder="Enter search term" (input)="onSearchChange($event)" />
-            </mat-form-field>
-            <div *ngIf="showClassFilter()">
-                <mat-card-title class="center-text">Class Filter</mat-card-title>
-                <div class="class-toggle-container">
-                    <button
-                        mat-raised-button
-                        *ngFor="let className of availableFilterableClasses"
-                        [class.selected]="isClassSelected(className)"
-                        [class.unselected]="!isClassSelected(className)"
-                        (click)="toggleClass(className)"
-                        class="class-toggle-button"
-                    >
-                        {{ className }}
-                    </button>
-                    <button mat-raised-button class="class-toggle-button unselected" (click)="resetClassFilter()">Reset</button>
-                </div>
+    <div class="bank-container">
+        <div class="bank-header">
+            <div class="last-updated-toast">
+                Last Updated: {{ lastModifiedDisplay$ | async }}
             </div>
-        </mat-card-content>
-    </mat-card>
 
-    <mat-tab-group class="custom-tab-group" animationDuration="0ms" (selectedTabChange)="onTabChange($event.index)">
-        <mat-tab *ngFor="let tab of bankData$ | async | keyvalue; trackBy: trackByTabKey">
-            <ng-template mat-tab-label>
-                {{ tab.key | titlecase }}
-            </ng-template>
-            <div class="bank-content">
-                <div class="card-container" *ngIf="tab.key === BankCategory.Epics || tab.key === BankCategory.Spells; else elseIfItem">
-                    <mat-card *ngFor="let class of (classesMap$ | async)?.get(tab.key)" class="spaced-card" appearance="outlined">
-                        <mat-card-content class="center-text bold-text">
-                            <mat-card-title>{{ class }}</mat-card-title>
-                            <mat-list>
-                                <mat-list-item *ngFor="let item of (classCategoryDataToBankEntryMap$ | async)?.get(tab.key)?.get(class);">
-                                    <item-display [item]="item" />
-                                </mat-list-item>
-                            </mat-list>
-                        </mat-card-content>
-                    </mat-card>
-                </div>
-                <ng-template #elseIfItem>
-                    <div class="card-container" *ngIf="tab.key === BankCategory.Items; else others">
-                        <mat-card *ngFor="let itemSlot of itemSlots$ | async" class="spaced-card" appearance="outlined">
+            <mat-card appearance="outlined">
+                <mat-card-content>
+                    <mat-form-field appearance="fill" class="spaced-input" subscriptSizing="dynamic">
+                        <mat-label>Search</mat-label>
+                        <input matInput placeholder="Enter search term" (input)="onSearchChange($event)" />
+                    </mat-form-field>
+                    <div *ngIf="showClassFilter()">
+                        <mat-card-title class="center-text">Class Filter</mat-card-title>
+                        <div class="class-toggle-container">
+                            <button
+                                mat-raised-button
+                                *ngFor="let className of availableFilterableClasses"
+                                [class.selected]="isClassSelected(className)"
+                                [class.unselected]="!isClassSelected(className)"
+                                (click)="toggleClass(className)"
+                                class="class-toggle-button"
+                            >
+                                {{ className }}
+                            </button>
+                            <button mat-raised-button class="class-toggle-button unselected" (click)="resetClassFilter()">Reset</button>
+                        </div>
+                    </div>
+                </mat-card-content>
+            </mat-card>
+        </div>
+
+        <mat-tab-group class="custom-tab-group" animationDuration="0ms" (selectedTabChange)="onTabChange($event.index)">
+            <mat-tab *ngFor="let tab of bankData$ | async | keyvalue; trackBy: trackByTabKey">
+                <ng-template mat-tab-label>
+                    {{ tab.key | titlecase }}
+                </ng-template>
+                <div class="bank-content">
+                    <div class="card-container" *ngIf="tab.key === BankCategory.Epics || tab.key === BankCategory.Spells; else elseIfItem">
+                        <mat-card *ngFor="let class of (classesMap$ | async)?.get(tab.key)" class="spaced-card" appearance="outlined">
                             <mat-card-content class="center-text bold-text">
-                                <mat-card-title>{{ ItemSlot[itemSlot] }}</mat-card-title>
+                                <mat-card-title>{{ class }}</mat-card-title>
                                 <mat-list>
-                                    <mat-list-item *ngFor="let item of (itemSlotBankEntryMap$ | async)?.get(itemSlot)">
+                                    <mat-list-item *ngFor="let item of (classCategoryDataToBankEntryMap$ | async)?.get(tab.key)?.get(class);">
                                         <item-display [item]="item" />
                                     </mat-list-item>
                                 </mat-list>
                             </mat-card-content>
                         </mat-card>
                     </div>
-                </ng-template>
-                <ng-template #others>
-                    <mat-list>
-                        <mat-list-item *ngFor="let item of tab.value">
-                            <item-display [item]="item" />
-                        </mat-list-item>
-                    </mat-list>
-                </ng-template>
-            </div>
-        </mat-tab>
-    </mat-tab-group>
+                    <ng-template #elseIfItem>
+                        <div class="card-container" *ngIf="tab.key === BankCategory.Items; else others">
+                            <mat-card *ngFor="let itemSlot of itemSlots$ | async" class="spaced-card" appearance="outlined">
+                                <mat-card-content class="center-text bold-text">
+                                    <mat-card-title>{{ ItemSlot[itemSlot] }}</mat-card-title>
+                                    <mat-list>
+                                        <mat-list-item *ngFor="let item of (itemSlotBankEntryMap$ | async)?.get(itemSlot)">
+                                            <item-display [item]="item" />
+                                        </mat-list-item>
+                                    </mat-list>
+                                </mat-card-content>
+                            </mat-card>
+                        </div>
+                    </ng-template>
+                    <ng-template #others>
+                        <mat-list>
+                            <mat-list-item *ngFor="let item of tab.value">
+                                <item-display [item]="item" />
+                            </mat-list-item>
+                        </mat-list>
+                    </ng-template>
+                </div>
+            </mat-tab>
+        </mat-tab-group>
+    </div>
 </ng-template>

--- a/src/app/@shared/@components/bank/bank.component.scss
+++ b/src/app/@shared/@components/bank/bank.component.scss
@@ -41,8 +41,6 @@ mat-card {
 }
 
 .bank-content {
-    max-height: calc(100vh - 170px);
-    overflow-y: auto;
     padding: 0 8px;
 }
 
@@ -59,6 +57,17 @@ mat-card-content a {
     gap: 8px;
     justify-content: center;
     margin-top: 16px;
+}
+
+.bank-container {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    overflow: hidden;
+}
+
+.bank-header {
+    flex-shrink: 0;
 }
 
 .class-toggle-button {
@@ -130,6 +139,10 @@ mat-card-content a {
   --mat-tab-header-active-hover-indicator-color: #ffe066;
   --mat-tab-header-active-hover-label-text-color: #ffe066;
   --mdc-tab-indicator-active-indicator-color: #ffe066; // Active tab indicator color
+
+  flex: 1 1 auto;
+  overflow-y: auto;
+  min-height: 0; // fix flexbox bug where content overflows with dynamic height elements
 }
 
 @media (max-width: 768px) {

--- a/src/app/@shared/@components/bank/bank.component.ts
+++ b/src/app/@shared/@components/bank/bank.component.ts
@@ -38,7 +38,7 @@ import { ItemDisplayComponent } from '../item-count/item-display.component';
 export class BankComponent {
     private _searchText$ = new BehaviorSubject<string | undefined>(undefined);
     private searchSubscription: Subscription | undefined;
-    private _filterableBankCategories: BankCategory[] = [BankCategory.Augs, BankCategory.Items];
+    private _filterableBankCategories: BankCategory[] = [BankCategory.Items];
     private _itemIdsByClass: ItemIdsByClass = {
         Bard: [],
         Beastlord: [],


### PR DESCRIPTION
- Scrollbar still didn't look right on multiple window sizes, so this removes the calc in favor of using flexbox.  The header will always take up as much space as needed, and the container below will fill the remainder of the viewport.
- Removed augs from class filters as requested.  We only have one class-specific aug, the Bloodstone, so it doesn't add a lot of value.

![css-scrollbar-fix](https://github.com/user-attachments/assets/1bdb2f6a-6df8-4a23-91da-3476435c8709)
