### PR TITLE
Remove the Additive Legendary for the base item link

### DIFF
--- a/src/app/@shared/@components/item-count/item-display.component.html
+++ b/src/app/@shared/@components/item-count/item-display.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="item; let itemDisplay">
     <h4 matLine>
         <ng-container *ngIf="itemDisplay.baseCount || itemDisplay.enchantedCount || itemDisplay.legendaryCount">
-            <a href="https://eqdb.net/item/detail/{{ itemDisplay.baseId + ItemQuality.Legendary }}" class="name-link" target="_blank">{{ itemDisplay.name }}</a>
+            <a href="https://eqdb.net/item/detail/{{ itemDisplay.baseId }}" class="name-link" target="_blank">{{ itemDisplay.name }}</a>
             <a href="https://eqdb.net/item/detail/{{ itemDisplay.baseId }}" *ngIf="itemDisplay.baseCount" class="green-text count-badge" target="_blank">{{
                 itemDisplay.baseCount
             }}</a


### PR DESCRIPTION
So for Song: Call of the Banshee its link is
https://eqdb.net/item/detail/2028481 but there is no Legendary item for Spells. So the id of 2028481 is invalid because the song is ID 28481. If I remove the additive LegendaryQuality then items link as their "base" version.