### PR TITLE
fix shared bank processing

### DIFF
--- a/src/app/@shared/@components/bank/bank.component.ts
+++ b/src/app/@shared/@components/bank/bank.component.ts
@@ -199,8 +199,7 @@ export class BankComponent {
 //const itemId = item.id.toString();
   
     for (const mapping of augSources.sourceMappings) {
-        //if (mapping.ids.some(idFromList => itemId.includes(idFromList.toString()))) {
-        if (mapping.ids.includes(itemId)) {
+        if (mapping.ids.includes(getBaseItemId(itemId))) {
             return mapping.source;
         }
     }

--- a/src/app/@shared/@components/item-count/item-display.component.scss
+++ b/src/app/@shared/@components/item-count/item-display.component.scss
@@ -6,6 +6,12 @@
   color: #ddd;
   text-decoration-line: none;
   margin-left: 3px;
+   -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  -webkit-tap-highlight-color: transparent;
 }
 .blue-text {
   color: rgb(35, 116, 255)

--- a/src/app/@shared/@components/item-count/item-display.component.scss
+++ b/src/app/@shared/@components/item-count/item-display.component.scss
@@ -6,7 +6,7 @@
   color: #ddd;
   text-decoration-line: none;
   margin-left: 3px;
-   -webkit-user-select: none;
+  -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;


### PR DESCRIPTION
Shared bank can be disabled on a per-tab basis:

const shouldIncludeSharedBank = ![BankCategory.Augs, BankCategory.Spells, BankCategory.Craft, BankCategory.Epics].includes(categoryEnum);

With this fix, it will only display on Items tab (per Videll)

Per request, made the item badges unable to be selected (for better compatibility with bank bot requests)